### PR TITLE
Fix README.md maintainer list to keep only active maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,11 +152,8 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
-* [@A-Baji](https://github.com/A-Baji/)
-* [@datajointbot](https://github.com/datajointbot/)
 * [@dimitri-yatsenko](https://github.com/dimitri-yatsenko/)
+* [@datajointbot](https://github.com/datajointbot/)
 * [@guzman-raphael](https://github.com/guzman-raphael/)
-* [@jverswijver](https://github.com/jverswijver/)
 * [@yambottle](https://github.com/yambottle/)
-* [@zitrosolrac](https://github.com/zitrosolrac/)
 

--- a/README.md
+++ b/README.md
@@ -156,4 +156,5 @@ Feedstock Maintainers
 * [@datajointbot](https://github.com/datajointbot/)
 * [@guzman-raphael](https://github.com/guzman-raphael/)
 * [@yambottle](https://github.com/yambottle/)
+* [@ttngu207](https://github.com/ttngu207/)
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
