### PR TITLE
Update to 0.14.7

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 {% set python_version = ">=3.9,<4.0" %}
 {% set python_version = ">=3.9,<4.0" %}
 {% set name = "datajoint" %}
-{% set version = "0.14.6" %}
+{% set version = "0.14.7" %}
 {% set python_version = ">=3.9,<4.0" %}
 
 package:
@@ -12,7 +12,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 1bd91c0c8a2a6d6521e95943dbff40751cc6c3893de9ae320a40f5211cc6f074
+  sha256: da2154288fd51713fa4d0cc787c9ad8fedce9fe428f56050073d17a19a40423b
 
 # build should be tested locally before PR, please save some resources for the community
 # conda install -n base conda-build boa conda-smithy


### PR DESCRIPTION
## Summary

Update datajoint to version 0.14.7

## Changes

- Version: 0.14.6 → 0.14.7
- sha256: updated for new release

## Release Notes

### Bug Fixes
- fix: Pass make_kwargs to make_fetch in tripartite pattern (#1360)

### Note
This is the **final maintenance release** for the 0.14.x branch. The next major version is v2.0.

See: https://github.com/datajoint/datajoint-python/releases/tag/v0.14.7