### PR TITLE
Update to DataJoint 2.0.1

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @datajointbot @dimitri-yatsenko @drewyangdev @guzman-raphael @ttngu207
+* @datajointbot @dimitri-yatsenko @ttngu207

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,7 @@ requirements:
   run:
     - python >={{ python_min }},<3.14
     - numpy
+    - packaging
     - pymysql >=0.7.2
     - deepdiff
     - pyparsing

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -69,8 +69,6 @@ about:
 
 extra:
   recipe-maintainers:
-    - guzman-raphael
     - dimitri-yatsenko
     - datajointbot
-    - drewyangdev
     - ttngu207

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "datajoint" %}
-{% set version = "2.0.0" %}
+{% set version = "2.0.1" %}
 {% set python_version = ">=3.10,<3.14" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 93e949128ba64b394c98352ec310449f8b238bf18c0401703d4ab1862cffc296
+  sha256: 69578ecb8ac778652bdea8be3e037fff6179a308629248aba163f51d062ae745
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "datajoint" %}
 {% set version = "2.0.1" %}
-{% set python_version = ">=3.10,<3.14" %}
+{% set python_min = "3.10" %}
 
 package:
   name: {{ name|lower }}
@@ -20,11 +20,11 @@ build:
 
 requirements:
   host:
-    - python {{ python_version }}
+    - python {{ python_min }}
     - pip
     - setuptools >=60
   run:
-    - python {{ python_version }}
+    - python >={{ python_min }},<3.14
     - numpy
     - pymysql >=0.7.2
     - deepdiff
@@ -41,7 +41,7 @@ requirements:
 
 test:
   requires:
-    - python {{ python_version }}
+    - python {{ python_min }}
   imports:
     - datajoint
   commands:


### PR DESCRIPTION
## Summary

Update datajoint to version 2.0.1

## Changes in 2.0.1

- **Bug Fix**: Allow table class names with underscores (with warning)
- **Bug Fix**: Add `fetch` to supported class attributes for class-level access
- **Enhancement**: Add deprecation warning to migrate module
- **Enhancement**: Remove unnecessary runtime dependencies

## Checklist

- [x] Version updated to 2.0.1
- [x] SHA256 updated
- [x] No dependency changes needed