### PR TITLE
Update to version 2.0.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "datajoint" %}
-{% set version = "2.0.1" %}
+{% set version = "2.0.2" %}
 {% set python_min = "3.10" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 69578ecb8ac778652bdea8be3e037fff6179a308629248aba163f51d062ae745
+  sha256: 8f5547db619e59ef8e0a8e7e03f4dbbc9cfce9a494a56270c8c5e1d90c5fea72
 
 build:
   noarch: python


### PR DESCRIPTION
## Changes

Update datajoint to version 2.0.2

### Bug Fixes in 2.0.2

- **fix: Support 'KEY' in fetch() for backward compatibility** (#1384)
- **fix: Handle inhomogeneous array shapes in to_arrays()** (#1382)
- **fix: Handle semantic_check for job table operations** (#1383)
- **fix: Handle missing SSL context in multiprocess populate** (#1377)

### Checklist

- [x] Used the PyPI sdist URL
- [x] Updated sha256 hash
- [x] Version bump only, no dependency changes