### PR TITLE
Update datajoint to 2.1.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
   host:
     - python {{ python_min }}
     - pip
-    - setuptools >=60
+    - hatchling
   run:
     - python >={{ python_min }},<3.14
     - numpy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "datajoint" %}
-{% set version = "2.0.2" %}
+{% set version = "2.1.0" %}
 {% set python_min = "3.10" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 8f5547db619e59ef8e0a8e7e03f4dbbc9cfce9a494a56270c8c5e1d90c5fea72
+  sha256: df93441640d86215bc8276b8cc8852f3dd55430588bd89689c82de36be0e2f11
 
 build:
   noarch: python


### PR DESCRIPTION
## Summary
- Update datajoint version from 2.0.2 to 2.1.0
- Update sha256 checksum

## Changelog
https://github.com/datajoint/datajoint-python/releases/tag/v2.1.0

### Key changes:
- **PostgreSQL backend support** — DataJoint now supports PostgreSQL as an alternative to MySQL
- Diagram improvements (collapse, Mermaid output, schema grouping)
- Singleton tables support
- Performance improvements (lazy loading)