### PR TITLE
Update datajoint to 0.14.9

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "datajoint" %}
-{% set version = "0.14.8" %}
+{% set version = "0.14.9" %}
 {% set python_version = ">=3.9,<4.0" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 5f2a117062fee344992654708165d113ed7021a5bed62021496767323184fbef
+  sha256: 8b82979c50812bb0b3102991299ef335e475979a9662c0363d7787dc90badba8
 
 # build should be tested locally before PR, please save some resources for the community
 # conda install -n base conda-build boa conda-smithy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "datajoint" %}
 {% set version = "0.14.9" %}
-{% set python_version = ">=3.9,<4.0" %}
+{% set python_version = ">=3.9,<3.13" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
## Changes

Update datajoint from 0.14.8 to 0.14.9.

### What's new in 0.14.9

- **Skip redundant S3 upload when file already exists** ([#1400](https://github.com/datajoint/datajoint-python/pull/1400)): After a transaction rollback, `upload_filepath` no longer re-uploads files that already exist in S3 with matching size and contents hash.
- **Pin setuptools<82 for pkg_resources compatibility** ([#1396](https://github.com/datajoint/datajoint-python/pull/1396))

PyPI: https://pypi.org/project/datajoint/0.14.9/
Release: https://github.com/datajoint/datajoint-python/releases/tag/v0.14.9