### PR TITLE
Update datajoint to 2.1.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "datajoint" %}
-{% set version = "2.1.0" %}
+{% set version = "2.1.1" %}
 {% set python_min = "3.10" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: df93441640d86215bc8276b8cc8852f3dd55430588bd89689c82de36be0e2f11
+  sha256: db2965db3a5d82a7c01084ea5cc773867e421288a37feb227affee37b2a40702
 
 build:
   noarch: python


### PR DESCRIPTION
## Changes

Update datajoint from 2.1.0 to 2.1.1.

### What's new in 2.1.1

- **Atomic job reservation to prevent race condition** ([#1399](https://github.com/datajoint/datajoint-python/pull/1399), fixes [#1398](https://github.com/datajoint/datajoint-python/issues/1398))
- **Hide comments from table preview display** ([#1393](https://github.com/datajoint/datajoint-python/pull/1393))
- **Correct Part table names in diagrams** ([#1392](https://github.com/datajoint/datajoint-python/pull/1392))
- **Remove deprecated `size_on_disk`** ([#1395](https://github.com/datajoint/datajoint-python/pull/1395))

PyPI: https://pypi.org/project/datajoint/2.1.1/
Release: https://github.com/datajoint/datajoint-python/releases/tag/v2.1.1