### PR TITLE
Update to v2.2.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "datajoint" %}
-{% set version = "2.2.1" %}
+{% set version = "2.2.2" %}
 {% set python_min = "3.10" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: ecb397775c64a3b9be3a17d6d94caecd4f451cc09faa210b86be73f134730a4e
+  sha256: ccf32feb59902e19736f086f47c29722f43644b06dd218cab11c8269b9af20e6
 
 build:
   noarch: python


### PR DESCRIPTION
Update datajoint to 2.2.2.

Changes: https://github.com/datajoint/datajoint-python/releases/tag/v2.2.2

**Enhancements**
- StorageAdapter plugin system for third-party storage protocols (#1432)
- Index query simplified; UserWarning emitted on MariaDB connections (#1439)
- `AutoPopulate` and `Job` exported in the public API (#1431)

**Bug fixes**
- `gc.scan_*_references` reads raw JSON metadata instead of decoded codec output, fixing a data-loss path that misclassified live `<blob@>` / `<npy@>` / `<object@>` references as orphaned (#1444)
- `json` columns on MariaDB now round-trip correctly (MariaDB stores them as `longtext`) (#1443)
- Clear `DataJointError` when a definition uses a leading-underscore attribute name, replacing the cryptic `pyparsing.ParseException` (#1441)
- `get_indexes_sql()` no longer depends on the `EXPRESSION` column (#1437)
- `migrate_columns()` preserves the `NOT NULL` constraint (#1435)