### PR TITLE
Update datajoint to 2.2.4

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -23,10 +23,14 @@ jobs:
       matrix:
         include:
           - CONFIG: linux_64_
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            tools_install_dir: ~/miniforge3
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
     steps:
 
     - name: Checkout code
@@ -36,11 +40,13 @@ jobs:
       id: build-linux
       if: matrix.os == 'ubuntu'
       env:
+        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
+        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
         CONFIG: ${{ matrix.CONFIG }}
         UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
         DOCKER_IMAGE: ${{ matrix.DOCKER_IMAGE }}
         CI: github_actions
-        CONDA_FORGE_DOCKER_RUN_ARGS: "${{ matrix.CONDA_FORGE_DOCKER_RUN_ARGS }}"
+        CONDA_FORGE_DOCKER_RUN_ARGS: "${{ matrix.docker_run_args }}"
         BINSTAR_TOKEN: ${{ secrets.BINSTAR_TOKEN }}
         FEEDSTOCK_TOKEN: ${{ secrets.FEEDSTOCK_TOKEN }}
         STAGING_BINSTAR_TOKEN: ${{ secrets.STAGING_BINSTAR_TOKEN }}
@@ -60,6 +66,8 @@ jobs:
         else
           export IS_PR_BUILD="False"
         fi
+        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
+        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
         echo "::endgroup::"
         ./.scripts/run_docker_build.sh
 
@@ -67,6 +75,8 @@ jobs:
       id: build-macos
       if: matrix.os == 'macos'
       env:
+        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
+        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
         CONFIG: ${{ matrix.CONFIG }}
         UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
         CI: github_actions
@@ -85,6 +95,8 @@ jobs:
         else
           export IS_PR_BUILD="False"
         fi
+        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
+        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
         ./.scripts/run_osx_build.sh
 
     - name: Build on windows
@@ -97,10 +109,8 @@ jobs:
         set "sha=%GITHUB_SHA%"
         call ".scripts\run_win_build.bat"
       env:
-        # default value; make it explicit, as it needs to match with artefact
-        # generation below. Not configurable for now, can be revisited later
-        CONDA_BLD_DIR: C:\bld
-        MINIFORGE_HOME: ${{ contains(runner.arch, 'ARM') && 'C' || 'D' }}:\Miniforge
+        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
+        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
         PYTHONUNBUFFERED: 1
         CONFIG: ${{ matrix.CONFIG }}
         CI: github_actions

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!.recipe_maintainers.json
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -36,7 +36,7 @@ mv /opt/conda/conda-meta/history /opt/conda/conda-meta/history.$(date +%Y-%m-%d-
 echo > /opt/conda/conda-meta/history
 micromamba install --root-prefix ~/.conda --prefix /opt/conda \
     --yes --override-channels --channel conda-forge --strict-channel-priority \
-    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=26.3"
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 # set up the condarc

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ Current build status
 <table><tr>
     <td>All platforms:</td>
     <td>
-      <img src="https://img.shields.io/badge/noarch-disabled-lightgrey.svg" alt="noarch disabled">
+      <a href="https://github.com/conda-forge/datajoint-feedstock/actions/workflows/conda-build.yml">
+        <img src="https://github.com/conda-forge/datajoint-feedstock/actions/workflows/conda-build.yml/badge.svg?event=push&branch=main">
+      </a>
     </td>
   </tr>
 </table>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "datajoint" %}
-{% set version = "2.2.2" %}
+{% set version = "2.2.4" %}
 {% set python_min = "3.10" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: ccf32feb59902e19736f086f47c29722f43644b06dd218cab11c8269b9af20e6
+  sha256: f9206a350257bc2ec864b5544bf1e8cb22e789416ab40d045e27e3d56bdcf27d
 
 build:
   noarch: python


### PR DESCRIPTION
## Summary

Bumps the recipe from 2.2.2 directly to **2.2.4**. 2.2.3 was released to PyPI earlier today but never landed on conda-forge — this PR supersedes the autotick bot's pending [#67 (v2.2.3)](https://github.com/conda-forge/datajoint-feedstock/pull/67).

The 2.2.4 release on PyPI rolls up the 2.2.3 env-var configuration work plus three small follow-up patches discovered during a docs review:

- env-var configuration of object stores: `DJ_STORES`, `DJ_IGNORE_CONFIG_FILE`, arbitrary `.secrets/stores.<name>.<attr>` ([datajoint-python#1452](https://github.com/datajoint/datajoint-python/pull/1452))
- `dj.StorageAdapter` + `dj.get_storage_adapter()` exposed at top level ([datajoint-python#1463](https://github.com/datajoint/datajoint-python/pull/1463))
- `packaging` declared as an explicit dependency ([datajoint-python#1462](https://github.com/datajoint/datajoint-python/pull/1462)) — fixes `import datajoint` on clean Python 3.12 venvs that no longer ship `setuptools` by default
- `settings.py` version-marker refresh ([datajoint-python#1461](https://github.com/datajoint/datajoint-python/pull/1461))

GitHub release: https://github.com/datajoint/datajoint-python/releases/tag/v2.2.4

PyPI sdist sha256: `f9206a350257bc2ec864b5544bf1e8cb22e789416ab40d045e27e3d56bdcf27d` (verified).

## Notes

- The recipe's run dependencies already include `packaging` (added in a prior recipe pass), so the runtime-dep fix from #1462 is a no-op for conda-forge — but it brings the upstream `pyproject.toml` and the recipe back in sync.
- No build-number reset needed (new version).
- The `dj.StorageAdapter` / `dj.get_storage_adapter` exports are tested via the existing `imports: - datajoint` smoke test plus the CLI entry-point tests.

## Checklist

- [x] Title bumps the version
- [x] sha256 verified against PyPI sdist
- [x] Run dependencies match `pyproject.toml` (numpy, pymysql, deepdiff, pyparsing, pandas, tqdm, networkx, pydot, fsspec, pydantic-settings, packaging)
- [x] License unchanged (Apache-2.0)
- [x] Maintainers unchanged

@conda-forge-admin, please rerender