### PR TITLE
datajoint v2.3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "datajoint" %}
-{% set version = "2.2.4" %}
+{% set version = "2.3.0" %}
 {% set python_min = "3.10" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: f9206a350257bc2ec864b5544bf1e8cb22e789416ab40d045e27e3d56bdcf27d
+  sha256: 559534161d6f5fdc2b6e93762a84c41872c6d3d6b6b65cd8e0444632b46ac196
 
 build:
   noarch: python


### PR DESCRIPTION
Updates `datajoint` to **v2.3.0**.

- `sha256` verified against the PyPI sdist (`datajoint-2.3.0.tar.gz`): `559534161d6f5fdc2b6e93762a84c41872c6d3d6b6b65cd8e0444632b46ac196`
- Build number reset to `0` (new version).
- **Dependencies unchanged** from 2.2.4 — verified the recipe `run` requirements against the package's `pyproject.toml` (same 11 runtime deps incl. `packaging`, same `python >=3.10,<3.14`). No re-render needed (version/sha bump only; no CI or dependency changes).

Upstream release: https://github.com/datajoint/datajoint-python/releases/tag/v2.3.0

### Checklist
- [x] Used a personal fork of the feedstock to propose changes
- [x] Bumped the build number (reset to 0 for the new version)
- [x] Re-rendered with the latest conda-smithy — not required (recipe-only version/sha bump)
- [x] Ensured the license file is being packaged (unchanged)