### PR TITLE
datajoint v2.3.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "datajoint" %}
-{% set version = "2.3.1" %}
+{% set version = "2.3.2" %}
 {% set python_min = "3.10" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 08f14db4c331ea1e57f1f57c3c736cb7a19f566e314fb6eb87b37fbccc136e2b
+  sha256: 47efee045b6eb346353132d4bcd41c58583b661ef880831357fc30227557f3fa
 
 build:
   noarch: python
@@ -23,6 +23,7 @@ requirements:
     - python {{ python_min }}
     - pip
     - hatchling
+    - hatch-vcs
   run:
     - python >={{ python_min }},<3.15
     - numpy


### PR DESCRIPTION
Updates the recipe to **datajoint 2.3.2** ([PyPI](https://pypi.org/project/datajoint/2.3.2/), [release notes](https://github.com/datajoint/datajoint-python/releases/tag/v2.3.2)).

Changes:
- `version` → `2.3.2`; `sha256` updated to the 2.3.2 sdist (verified against the PyPI `datajoint-2.3.2.tar.gz`).
- **Added `hatch-vcs` to `host`.** 2.3.2 derives its version from the git tag via `hatch-vcs`, so `build-system.requires` is now `["hatchling", "hatch-vcs"]`; the recipe host must provide it. Building from the PyPI sdist resolves the version from `PKG-INFO`, so no VCS metadata is needed at build time.
- Runtime dependencies are unchanged from 2.3.1 (verified against `pyproject.toml`); build number reset to 0 for the new version.

Checklist:
- [x] Used a personal fork of the feedstock to propose changes
- [x] Bumped the build number (reset to 0 for a version bump)
- [x] Reset the build number to 0 (new version)
- [x] Re-rendered with the latest conda-smithy (not required: version + dependency bump only, no CI/infra change)
- [x] Ensured the license file is packaged (`license_file: LICENSE`, unchanged)
